### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/325/29/85632529.geojson
+++ b/data/856/325/29/85632529.geojson
@@ -981,6 +981,10 @@
     },
     "wof:country":"AG",
     "wof:country_alpha3":"ATG",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"ce04e2cef3b7f6b59f76950716b4ca2a",
     "wof:hierarchy":[
         {
@@ -995,7 +999,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566584569,
+    "wof:lastmodified":1582326308,
     "wof:name":"Antigua and Barbuda",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.