### PR TITLE
ag concordances, placetype local, and more

### DIFF
--- a/data/856/325/29/85632529.geojson
+++ b/data/856/325/29/85632529.geojson
@@ -1155,6 +1155,7 @@
         "hasc:id":"AG",
         "icao:code":"V2",
         "ioc:id":"ANT",
+        "iso:code":"AG",
         "itu:id":"ATG",
         "loc:id":"n83129820",
         "m49:code":"028",
@@ -1168,6 +1169,7 @@
         "wk:page":"Antigua and Barbuda",
         "wmo:id":"AT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
     "wof:country_alpha3":"ATG",
     "wof:geom_alt":[
@@ -1188,7 +1190,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639518,
+    "wof:lastmodified":1695881174,
     "wof:name":"Antigua and Barbuda",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/681/61/85668161.geojson
+++ b/data/856/681/61/85668161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014435,
-    "geom:area_square_m":170102833.871726,
+    "geom:area_square_m":170102823.286307,
     "geom:bbox":"-61.87385,17.545559,-61.727773,17.727688",
     "geom:latitude":17.631888,
     "geom:longitude":-61.795268,
@@ -368,13 +368,15 @@
         "gn:id":3576390,
         "gp:id":2344541,
         "hasc:id":"AG.BB",
+        "iso:code":"AG-10",
         "iso:id":"AG-10",
         "qs_pg:id":1310678,
         "wd:id":"Q238752",
         "wk:page":"Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"6c826146dbeb319f8e980eda412199f9",
+    "wof:geomhash":"62ce361505db5667c9b57ab77b5f5e19",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -389,7 +391,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849656,
+    "wof:lastmodified":1695884323,
     "wof:name":"Barbuda",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/67/85668167.geojson
+++ b/data/856/681/67/85668167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000031,
-    "geom:area_square_m":370391.448221,
+    "geom:area_square_m":370350.648221,
     "geom:bbox":"-62.34826,16.93197,-62.342918,16.940897",
     "geom:latitude":16.93605,
     "geom:longitude":-62.345277,
@@ -309,12 +309,14 @@
         "gn:id":3576037,
         "gp:id":-99,
         "hasc:id":"AG.RD",
+        "iso:code":"AG-11",
         "iso:id":"AG-11",
         "unlc:id":"AG-11",
         "wd:id":"Q457261"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"f07e3987759eaeab1cfbf502ae14f73b",
+    "wof:geomhash":"d05c36405c0e5e8d51e09dd93772aa3d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849656,
+    "wof:lastmodified":1695884843,
     "wof:name":"Redonda",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/71/85668171.geojson
+++ b/data/856/681/71/85668171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002367,
-    "geom:area_square_m":27966690.201169,
+    "geom:area_square_m":27966848.442615,
     "geom:bbox":"-61.805843,17.071428,-61.755841,17.164944",
     "geom:latitude":17.112454,
     "geom:longitude":-61.781843,
@@ -287,14 +287,16 @@
         "gn:id":3576024,
         "gp:id":2344542,
         "hasc:id":"AG.GE",
+        "iso:code":"AG-03",
         "iso:id":"AG-03",
         "qs_pg:id":1310679,
         "unlc:id":"AG-03",
         "wd:id":"Q1770796",
         "wk:page":"Saint George Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"56b97be7f92b192f1625c17552101293",
+    "wof:geomhash":"334b3dd43d1d1f1c6445f94a10262905",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849658,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint George",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/73/85668173.geojson
+++ b/data/856/681/73/85668173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002686,
-    "geom:area_square_m":31750225.825144,
+    "geom:area_square_m":31750052.185763,
     "geom:bbox":"-61.774209,17.060203,-61.708608,17.141506",
     "geom:latitude":17.095432,
     "geom:longitude":-61.744201,
@@ -272,14 +272,16 @@
         "gn:id":3576016,
         "gp:id":2344546,
         "hasc:id":"AG.PE",
+        "iso:code":"AG-07",
         "iso:id":"AG-07",
         "qs_pg:id":1083776,
         "unlc:id":"AG-07",
         "wd:id":"Q1952603",
         "wk:page":"Saint Peter Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"ed3959a61c50b8f7a93dd57762aabc2a",
+    "wof:geomhash":"0b9a9b796b954f03d50cc76756e3a089",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849657,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/77/85668177.geojson
+++ b/data/856/681/77/85668177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003221,
-    "geom:area_square_m":38072610.064365,
+    "geom:area_square_m":38072472.312763,
     "geom:bbox":"-61.733392,17.027818,-61.667592,17.100531",
     "geom:latitude":17.063832,
     "geom:longitude":-61.70158,
@@ -278,14 +278,16 @@
         "gn:id":3576015,
         "gp:id":2344547,
         "hasc:id":"AG.PH",
+        "iso:code":"AG-08",
         "iso:id":"AG-08",
         "qs_pg:id":898606,
         "unlc:id":"AG-08",
         "wd:id":"Q1996895",
         "wk:page":"Saint Philip Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"9e4691a1dcbb3ef7e8ad5ac420a25f41",
+    "wof:geomhash":"7517a8db44988ab4ac0ebd2d25515756",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849658,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint Philip",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/81/85668181.geojson
+++ b/data/856/681/81/85668181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004305,
-    "geom:area_square_m":50901954.014217,
+    "geom:area_square_m":50902218.586706,
     "geom:bbox":"-61.815027,16.989244,-61.726226,17.064285",
     "geom:latitude":17.032579,
     "geom:longitude":-61.766957,
@@ -287,14 +287,16 @@
         "gn:id":3576017,
         "gp:id":2344545,
         "hasc:id":"AG.PA",
+        "iso:code":"AG-06",
         "iso:id":"AG-06",
         "qs_pg:id":1310682,
         "unlc:id":"AG-06",
         "wd:id":"Q386093",
         "wk:page":"Saint Paul Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"06da48c9ae57f273e95c75c4e8fe2960",
+    "wof:geomhash":"02177ed43e5ce68f3c6beb7b9213e970",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849657,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint Paul",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/87/85668187.geojson
+++ b/data/856/681/87/85668187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004922,
-    "geom:area_square_m":58189826.247826,
+    "geom:area_square_m":58189703.814342,
     "geom:bbox":"-61.89037,17.004828,-61.804067,17.094898",
     "geom:latitude":17.044739,
     "geom:longitude":-61.848479,
@@ -266,14 +266,16 @@
         "gn:id":3576018,
         "gp:id":2344544,
         "hasc:id":"AG.MA",
+        "iso:code":"AG-05",
         "iso:id":"AG-05",
         "qs_pg:id":1310681,
         "unlc:id":"AG-05",
         "wd:id":"Q1999872",
         "wk:page":"Saint Mary Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"0450f122b3aecce6ef1c82fb32d6220b",
+    "wof:geomhash":"e59d3ba20bcff9059a139fea6ac85ea8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -288,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849657,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint Mary",
     "wof:parent_id":85632529,
     "wof:placetype":"region",

--- a/data/856/681/91/85668191.geojson
+++ b/data/856/681/91/85668191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006432,
-    "geom:area_square_m":76018924.418871,
+    "geom:area_square_m":76019003.705703,
     "geom:bbox":"-61.894154,17.042856,-61.774209,17.168769",
     "geom:latitude":17.109063,
     "geom:longitude":-61.825588,
@@ -251,14 +251,16 @@
         "gn:id":3576023,
         "gp:id":2344543,
         "hasc:id":"AG.JO",
+        "iso:code":"AG-04",
         "iso:id":"AG-04",
         "qs_pg:id":1310680,
         "unlc:id":"AG-04",
         "wd:id":"Q548816",
         "wk:page":"Saint John Parish, Antigua and Barbuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AG",
-    "wof:geomhash":"ab8b46af1648ec4b53966d6309552e8b",
+    "wof:geomhash":"a7efd15fabc264157ab57f778565913c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -273,7 +275,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690849657,
+    "wof:lastmodified":1695884843,
     "wof:name":"Saint John",
     "wof:parent_id":85632529,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.